### PR TITLE
Add support for tagged releases to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,29 @@ sudo: required
 
 language: scala
 
+services:
+  - docker
+
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 
 script:
-  - pushd mosaic
-  - ./sbt test
-  - popd
+  - mkdir -p ${HOME}/.sbt
+  - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/rf-tiler -w /rf-tiler/mosaic quay.io/azavea/scala:latest ./sbt test
+
+before_deploy:
+  - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/rf-tiler -w /rf-tiler/mosaic quay.io/azavea/scala:latest ./sbt assembly
+  - sudo chown ${USER} mosaic/target/scala-2.10/rf-tiler-assembly-${TRAVIS_TAG}.jar
+
+deploy:
+  provider: releases
+  api_key:
+    secure: MVSdM3LhXxuXV7ytcxY3VI5WVQ4mkgf3LwW0AbtHJuQjiaew6G/IqNeJzcdDmg38WTQdGd/wcxUQvtqD6bfZyKP35FXvUTSMxLh/BHUhCPSnl5w8I/0dhiCes2JOb/zH4D1Lbrq1OWRHaoFfVnCC4pWNnF6jEwdRsqPPwIRDH6tSmjd/i5O2/1uzoq8yaMnkjnAbSWy/evxA06KEwPVn4ADX6aIqd7dC/vma2pyVQ5bSSyiF7gJwhaK8tH4JZ9Qq9MjJZYIXApUt95D7gl8kEvdpkrIPqzt0wn74HIxmPsIxW2+ZJG35EfmPTDfnSsA7mXAWkAR71nvttpBFM0edLzk992RAHr8KeaCSVizeRDxhVt/PXMJgAfcgPP+RLOl02or53Lm7yf202hTqM67I+0bpG0rJKVMkCejtN3qIadZLu22gCrLIsvBq3eypRW9xdDwtYKUzGu659K+TcUz7uMzr+0Pe2xcVHcnkXjAVZ904NXjEoIjjQc6mNL8Gz/0av+w2wZpYX04JcwkMqdurVxoFT43STSiiV2KYBF06zz8bptJPNX/sK7UK/WebdtstFUrs5Vhg9T/L3pHjCuaivGiVWH4rqGIwcfEpj4ZRuZFWL25Q6cLCtL6eHSbuV+Jju7MQpLgk+FRGTHaPHDZ031dn7AqqVmeuFAtTaZ5uVYo=
+  file:
+    - mosaic/target/scala-2.10/rf-tiler-assembly-${TRAVIS_TAG}.jar
+  skip_cleanup: true
+  on:
+    repo: azavea/raster-foundry-tiler
+    tags: true


### PR DESCRIPTION
First, run test suite inside of a Scala container (Java 7). If the tests pass, use the same container image to build an assembly JAR. Finally, if commit is associated with a tag, use the Travis CI deployment support for GitHub Releases to publish the assembly JAR.

Only the last commit here is relevant. This pull request builds off of https://github.com/azavea/raster-foundry-tiler/pull/1.